### PR TITLE
migration: add migration support, add complexity -> difficulty migration

### DIFF
--- a/db/fake_data.sql
+++ b/db/fake_data.sql
@@ -1,12 +1,12 @@
 INSERT INTO maps
-  (id, submission_date, title, artist, author, uploader, description, album_art)
+  (id, submission_date, title, artist, author, uploader, description, complexity, album_art)
 VALUES
-  ('1', timestamp '2021-06-01 00:00:00', 'All Star', 'Smash Mouth', 'anon', 'anon', 'All Star is the greatest hit of all time.', 'https://upload.wikimedia.org/wikipedia/en/3/30/Astro_lounge.png');
+  ('1', timestamp '2021-06-01 00:00:00', 'All Star', 'Smash Mouth', 'anon', 'anon', 'All Star is the greatest hit of all time.', 2, 'https://upload.wikimedia.org/wikipedia/en/3/30/Astro_lounge.png');
 
-INSERT INTO complexities
-  (map_id, complexity, complexity_name)
+INSERT INTO difficulties
+  (map_id, difficulty, difficulty_name)
 VALUES
-  ('1', 1, 'anon''s Easy'),
-  ('1', 2, 'Medium'),
-  ('1', 3, 'This map has layers'),
-  ('1', 5, 'Shrek is love, Shrek is life');
+  ('1', null, 'anon''s Easy'),
+  ('1', null, 'Medium'),
+  ('1', null, 'This map has layers'),
+  ('1', null, 'Shrek is love, Shrek is life');

--- a/db/init.sql
+++ b/db/init.sql
@@ -6,13 +6,14 @@ CREATE TABLE maps (
   author varchar(256),
   uploader varchar(256) not null,
   description text,
+  complexity int,
   album_art text
 );
 
-CREATE TABLE complexities (
+CREATE TABLE difficulties (
   map_id varchar(16) references maps (id) not null,
-  complexity int not null,
-  complexity_name varchar(256)
+  difficulty int,
+  difficulty_name varchar(256)
 );
 
 CREATE TABLE users (

--- a/db/migrations/1_complexities_to_difficulties.sql
+++ b/db/migrations/1_complexities_to_difficulties.sql
@@ -1,0 +1,17 @@
+ALTER TABLE complexities
+ALTER COLUMN complexity DROP NOT NULL;
+
+ALTER TABLE complexities
+RENAME COLUMN complexity TO difficulty;
+
+ALTER TABLE complexities
+RENAME COLUMN complexity_name TO difficulty_name;
+
+ALTER TABLE complexities
+RENAME CONSTRAINT "complexities_map_id_fkey" TO "difficulties_map_id_fkey";
+
+ALTER TABLE complexities
+RENAME TO difficulties;
+
+ALTER TABLE maps
+ADD COLUMN complexity int;

--- a/db/migrations/3_complexity_not_null.sql
+++ b/db/migrations/3_complexity_not_null.sql
@@ -1,0 +1,9 @@
+/* To be run after all maps have a populated complexity value, and after all difficulties
+ * have a populated difficulty_ame value (taken from the .rlrr file in the stored zip).
+ */
+
+ALTER TABLE maps
+ALTER COLUMN complexity SET NOT NULL;
+
+ALTER TABLE difficulties
+ALTER COLUMN difficulty_name SET NOT NULL;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "scripts": {
     "start": "nodemon src/index.ts",
-    "schema": "tools/update_schema.sh"
+    "schema": "tools/update_schema.sh",
+    "outage": "ts-node src/outage/index.ts"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",

--- a/src/_migrations/2_write_complexity_and_difficulties.ts
+++ b/src/_migrations/2_write_complexity_and_difficulties.ts
@@ -1,0 +1,80 @@
+import { snakeCaseKeys } from 'db/helpers';
+import { validateMapFiles } from 'db/maps/maps_repo';
+import { pool } from 'db/pool';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as unzipper from 'unzipper';
+import * as db from 'zapatos/db';
+import { setupMigration } from './migration';
+
+async function processMap(mapPath: string) {
+  const basename = path.basename(mapPath);
+  const id = basename.match(/(M[A-F0-9]{6})\.zip/)?.[1];
+  if (id == null) {
+    return;
+  }
+  const existing = await db.selectOne('maps', { id }).run(pool);
+  if (existing == null) {
+    return;
+  }
+  const buffer = await fs.readFile(mapPath);
+  const map = await unzipper.Open.buffer(buffer);
+  const mapFiles = map.files.filter(f => f.type === 'File');
+  const validatedMap = await validateMapFiles({ mapFiles });
+  if (!validatedMap.success) {
+    throw new Error(
+      `Map validation failed for path: ${mapPath}: ${JSON.stringify(validatedMap.errors)}`,
+    );
+  }
+
+  // Insert new difficulties
+  await db
+    .insert(
+      'difficulties',
+      validatedMap
+        .value
+        .difficulties
+        .map(d =>
+          snakeCaseKeys({
+            mapId: id,
+            difficulty: d.difficulty || null,
+            difficultyName: d.difficultyName || null,
+          })
+        ),
+    )
+    .run(pool);
+
+  // Update the map complexity to the complexity found in the first available difficulty
+  const complexity = validatedMap.value.complexity;
+  await db.update('maps', { complexity }, { id }).run(pool);
+}
+
+/**
+ * This migration script is expected to run AFTER `1_complexities_to_difficulties.sql`, and BEFORE
+ * `3_complexity_not_null.sql`.
+ * It will go through all stored maps and reinsert the difficulties found in the .rlrr files into the
+ * difficulties table.
+ */
+(async () => {
+  const envVars = await setupMigration();
+
+  // Drop all map difficulties
+  await db.truncate('difficulties').run(pool);
+
+  // Re-add all map difficulties
+  const entries = await fs.readdir(envVars.mapsDir);
+  const stats = await Promise.all(entries.map(async e => {
+    const fullPath = path.resolve(envVars.mapsDir, e);
+    const stat = await fs.stat(fullPath);
+    return { fullPath, stat };
+  }));
+  const files = stats
+    .filter(s => s.stat.isFile() && s.fullPath.endsWith('.zip'))
+    .map(s => s.fullPath);
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    await processMap(file);
+    console.log(`Processed ${i + 1} / ${files.length}`);
+  }
+})();

--- a/src/_migrations/migration.ts
+++ b/src/_migrations/migration.ts
@@ -1,0 +1,12 @@
+import { initPool } from 'db/pool';
+import { initEnvVars } from 'env';
+import path from 'path';
+
+export const setupMigration = async () => {
+  require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
+  const envVars = initEnvVars();
+  await initPool();
+  return envVars;
+};
+
+// TODO: setup a test DB framework for testing migrations over fake data

--- a/src/api/maps/maps.ts
+++ b/src/api/maps/maps.ts
@@ -1,6 +1,6 @@
 import { error, guardAuth, handleAsyncErrors } from 'api/helpers';
 import { createMap, deleteMap, getMap, GetMapError, listMaps } from 'db/maps/maps_repo';
-import { Response, Router } from 'express';
+import { Request, Response, Router } from 'express';
 import {
   deserializeSubmitMapRequest,
   serializeApiError,
@@ -47,7 +47,7 @@ export function createMapsRouter(mapsDir: string) {
     return res.send(Buffer.from(serializeGetMapResponse({ success: true, map: result.value })));
   });
 
-  mapsRouter.post('/:mapId/delete', guardAuth, async (req, res: Response<Buffer, {}>) => {
+  mapsRouter.post('/:mapId/delete', guardAuth, async (req: Request, res: Response<Buffer, {}>) => {
     const id = req.params.mapId;
     const getResult = await getMap(id);
     if (getResult.success === false) {
@@ -89,7 +89,7 @@ export function createMapsRouter(mapsDir: string) {
     return res.send(Buffer.from(serializeDeleteMapResponse({ success: true })));
   });
 
-  mapsRouter.post('/submit', guardAuth, async (req, res: Response<Buffer, {}>, next) => {
+  mapsRouter.post('/submit', guardAuth, async (req: Request, res: Response<Buffer, {}>, next) => {
     handleAsyncErrors(next, async () => {
       const user = getUserSession(req, res);
       if (!user) {

--- a/src/db/maps/maps_repo.ts
+++ b/src/db/maps/maps_repo.ts
@@ -1,8 +1,8 @@
 import { checkExists } from 'base/conditions';
-import { PromisedResult, Result, ResultSuccess } from 'base/result';
+import { PromisedResult, Result, ResultError } from 'base/result';
 import { camelCaseKeys, snakeCaseKeys } from 'db/helpers';
 import { generateId, IdDomain } from 'db/id_gen';
-import pool from 'db/pool';
+import { pool } from 'db/pool';
 // @ts-ignore
 import * as encoding from 'encoding';
 import * as fs from 'fs/promises';
@@ -19,8 +19,8 @@ export async function listMaps(): PromisedResult<PDMap[], ListMapError> {
     const maps = await db
       .select('maps', db.all, {
         lateral: {
-          complexities: db.select('complexities', { map_id: db.parent('id') }, {
-            columns: ['complexity', 'complexity_name'],
+          difficulties: db.select('difficulties', { map_id: db.parent('id') }, {
+            columns: ['difficulty', 'difficulty_name'],
           }),
         },
         columns: [
@@ -51,8 +51,8 @@ export async function getMap(id: string): PromisedResult<PDMap, GetMapError> {
     const map = await db
       .selectOne('maps', { id }, {
         lateral: {
-          complexities: db.select('complexities', { map_id: db.parent('id') }, {
-            columns: ['complexity', 'complexity_name'],
+          difficulties: db.select('difficulties', { map_id: db.parent('id') }, {
+            columns: ['difficulty', 'difficulty_name'],
           }),
         },
         columns: [
@@ -86,7 +86,7 @@ export async function deleteMap(id: string): PromisedResult<undefined, DeleteMap
       pool,
       client =>
         Promise.all([
-          db.deletes('complexities', { map_id: id }).run(client),
+          db.deletes('difficulties', { map_id: id }).run(client),
           db.deletes('maps', { id }).run(client),
         ]),
     );
@@ -108,7 +108,7 @@ export const enum CreateMapError {
 export async function createMap(
   mapsDir: string,
   opts: CreateMapOpts,
-): PromisedResult<PDMap, CreateMapError | ValidateMapError | ValidateMapComplexityError> {
+): PromisedResult<PDMap, CreateMapError | ValidateMapError | ValidateMapDifficultyError> {
   const id = await generateId(IdDomain.MAPS, async id => (await getMap(id)).success);
   if (id == null) {
     return { success: false, errors: [{ type: CreateMapError.TOO_MANY_ID_GEN_ATTEMPTS }] };
@@ -135,34 +135,38 @@ export async function createMap(
           uploader: opts.uploader,
           albumArt: map.albumArt || null,
           description: map.description || null,
+          complexity: map.complexity,
         }),
       )
       .run(pool);
-    const insertedComplexities = await db
+    const insertedDifficulties = await db
       .insert(
-        'complexities',
-        map.complexities.map(c =>
+        'difficulties',
+        map.difficulties.map(d =>
           snakeCaseKeys({
             mapId: id,
-            complexity: c.complexity,
-            complexityName: c.complexityName || null,
+            difficulty: d.difficulty || null,
+            difficultyName: d.difficultyName || null,
           })
         ),
       )
       .run(pool);
     return {
       success: true,
-      value: camelCaseKeys({ ...insertedMap, complexities: insertedComplexities }),
+      value: camelCaseKeys({ ...insertedMap, difficulties: insertedDifficulties }),
     };
   } catch (e) {
     return { success: false, errors: [{ type: CreateMapError.UNKNOWN_DB_ERROR }] };
   }
 }
 
-type RawMap = Pick<PDMap, 'title' | 'artist' | 'author' | 'description' | 'complexities'>;
+type RawMap = Pick<
+  PDMap,
+  'title' | 'artist' | 'author' | 'description' | 'complexity' | 'difficulties'
+>;
 export const enum ValidateMapError {
-  MISMATCHED_COMPLEXITY_METADATA = 'mismatched_complexity_metadata',
-  MISSING_SUBFOLDER = 'missing_subfolder',
+  MISMATCHED_DIFFICULTY_METADATA = 'mismatched_difficulty_metadata',
+  INCORRECT_FOLDER_STRUCTURE = 'incorrect_folder_structure',
   INCORRECT_FOLDER_NAME = 'incorrect_folder_name',
   NO_DATA = 'no_data',
   MISSING_ALBUM_ART = 'missing_album_art',
@@ -171,22 +175,21 @@ async function storeFile(
   opts: { id: string, mapsDir: string, mapFile: ArrayBuffer },
 ): PromisedResult<
   RawMap & { path: string } & Pick<PDMap, 'albumArt'>,
-  ValidateMapError | ValidateMapComplexityError
+  ValidateMapError | ValidateMapDifficultyError
 > {
   const buffer = Buffer.from(opts.mapFile);
   const map = await unzipper.Open.buffer(buffer);
-  // A submitted map must have exactly one directory in it, and all of the files must be under
-  // that directory.
+  // A submitted map must have exactly one directory in it, and all of the files must be directly
+  // under that directory.
   const files = map.files.filter(f => f.type === 'File');
-  const mapNameMatch = files[0].path.match(/(.+?)\//);
-  let mapName = mapNameMatch ? mapNameMatch[1] : null;
+  let mapName = files[0].path.match(/(.+?)\//)?.[1];
   if (mapName?.startsWith('/')) {
     mapName = mapName.substring(1);
   }
-  if (mapName == null || !files.every(f => f.path.startsWith(mapName + '/'))) {
-    return { success: false, errors: [{ type: ValidateMapError.MISSING_SUBFOLDER }] };
+  if (mapName == null || !files.every(f => path.dirname(f.path) === mapName)) {
+    return { success: false, errors: [{ type: ValidateMapError.INCORRECT_FOLDER_STRUCTURE }] };
   }
-  const validatedResult = await validateMapFiles({ ...opts, mapFiles: files });
+  const validatedResult = await validateMapFiles({ mapFiles: files });
   if (!validatedResult.success) {
     return validatedResult;
   }
@@ -195,7 +198,8 @@ async function storeFile(
   if (validatedResult.value.title !== mapName) {
     return { success: false, errors: [{ type: ValidateMapError.INCORRECT_FOLDER_NAME }] };
   }
-  const { title, artist, author, description, complexities, albumArtFiles } = validatedResult.value;
+  const { title, artist, author, description, complexity, difficulties, albumArtFiles } =
+    validatedResult.value;
   const { mapFilePath, albumArt } = await writeMapFiles({
     id: opts.id,
     mapsDir: opts.mapsDir,
@@ -204,52 +208,72 @@ async function storeFile(
   });
   return {
     success: true,
-    value: { title, artist, author, description, complexities, path: mapFilePath, albumArt },
+    value: {
+      title,
+      artist,
+      author,
+      description,
+      complexity,
+      difficulties,
+      path: mapFilePath,
+      albumArt,
+    },
   };
 }
 
 function allExists<T>(a: (T | undefined)[]): a is T[] {
   return a.every(t => t != null);
 }
-async function validateMapFiles(
-  opts: { mapFiles: unzipper.File[], id: string, mapsDir: string },
+export async function validateMapFiles(
+  opts: { mapFiles: unzipper.File[] },
 ): PromisedResult<
   RawMap & { albumArtFiles: unzipper.File[] },
-  ValidateMapError | ValidateMapComplexityError
+  ValidateMapError | ValidateMapDifficultyError
 > {
-  const complexityResults = await Promise.all(
+  const difficultyResults = await Promise.all(
     opts
       .mapFiles
       .filter(f => f.path.endsWith('.rlrr'))
-      .map(f => f.buffer().then(b => validateComplexity(path.basename(f.path), b))),
+      .map(f => f.buffer().then(b => validateMapMetadata(path.basename(f.path), b))),
   );
-  if (complexityResults.length === 0) {
+  if (difficultyResults.length === 0) {
     return { success: false, errors: [{ type: ValidateMapError.NO_DATA }] };
   }
-  const firstError = complexityResults.find(m => m.success === false);
+  const firstError = difficultyResults.find(m => m.success === false);
   if (firstError && firstError.success === false) {
     return { success: false, errors: firstError.errors };
   }
-  const validComplexityResults = complexityResults as ResultSuccess<RawMapComplexity>[];
+
+  const validDifficultyResults = difficultyResults as Exclude<
+    (typeof difficultyResults)[number],
+    ResultError<ValidateMapDifficultyError>
+  >[];
 
   // Check that all maps have the same metadata.
-  for (let i = 1; i < validComplexityResults.length; i++) {
-    const map = validComplexityResults[i].value;
-    // All fields except 'complexity' should match
+  for (let i = 1; i < validDifficultyResults.length; i++) {
+    const map = validDifficultyResults[i].value;
     for (const [key, value] of Object.entries(map)) {
-      if (key === 'complexity') {
+      // Difficulty name is expected to change between difficulties.
+      // Complexity is not, but some existing maps have mismatched complexities between rlrr files,
+      // and so this check has been skipped temporarily.
+      // TODO: fix all maps with mismatched complexities
+      if (key === 'difficultyName' || key === 'complexity') {
         continue;
       }
-      if (value !== validComplexityResults[0].value[key as keyof RawMapComplexity]) {
+      const expected = validDifficultyResults[0].value[key as keyof RawMapMetadata];
+      if (value !== expected) {
         return {
           success: false,
-          errors: [{ type: ValidateMapError.MISMATCHED_COMPLEXITY_METADATA }],
+          errors: [{
+            type: ValidateMapError.MISMATCHED_DIFFICULTY_METADATA,
+            message: `mismatched '${key}': '${value}' vs '${expected}'`,
+          }],
         };
       }
     }
   }
 
-  const albumArtFiles = validComplexityResults
+  const albumArtFiles = validDifficultyResults
     .map(v => v.value.albumArt)
     .filter((s): s is string => s != null)
     .map(fn => opts.mapFiles.find(f => path.basename(f.path) === fn));
@@ -261,18 +285,19 @@ async function validateMapFiles(
   return {
     success: true,
     value: {
-      title: validComplexityResults[0].value.title,
-      artist: validComplexityResults[0].value.artist,
-      author: validComplexityResults[0].value.author,
-      description: validComplexityResults[0].value.description,
-      complexities: validComplexityResults
-        .map(c => ({
-          complexity: c.value.complexity,
-          // Currently, custom complexity names are not supported in the rlrr format. Persist them as
-          // undefined for now, and use the FE fallback for Easy/Normal/Hard/Expert on render.
-          complexityName: undefined,
-        }))
-        .sort((a, b) => a.complexity - b.complexity),
+      title: validDifficultyResults[0].value.title,
+      artist: validDifficultyResults[0].value.artist,
+      author: validDifficultyResults[0].value.author,
+      description: validDifficultyResults[0].value.description,
+      complexity: validDifficultyResults[0].value.complexity,
+      difficulties: validDifficultyResults
+        .map(d => ({
+          // Currently, custom difficulty values are not supported in the rlrr format. Persist them as
+          // undefined for now, and look into generating a difficulty level later based on the map
+          // content.
+          difficulty: undefined,
+          difficultyName: path.basename(d.value.difficultyName),
+        })),
       albumArtFiles,
     },
   };
@@ -287,7 +312,7 @@ async function writeMapFiles(
   await fs.writeFile(filepath, opts.buffer);
 
   // For now, write all of the album art files to the album art directory.
-  // TODO: display all of the album arts in the FE, e.g. in a carousel, or when selecting a complexity
+  // TODO: display all of the album arts in the FE, e.g. in a carousel, or when selecting a difficulty
   const albumArtFolderPath = path.resolve(opts.mapsDir, opts.id);
   await fs.mkdir(albumArtFolderPath);
   await Promise.all(opts.albumArtFiles.map(a => {
@@ -305,26 +330,27 @@ async function writeMapFiles(
   };
 }
 
-type RawMapComplexity = Pick<PDMap, 'title' | 'artist' | 'author' | 'albumArt' | 'description'> & {
-  complexity: number,
-};
-export const enum ValidateMapComplexityError {
+type RawMapMetadata = Pick<
+  PDMap,
+  'title' | 'artist' | 'author' | 'albumArt' | 'description' | 'complexity'
+>;
+export const enum ValidateMapDifficultyError {
   INVALID_FORMAT = 'invalid_format',
   MISSING_VALUES = 'missing_values',
 }
-function validateComplexity(
+function validateMapMetadata(
   filename: string,
   mapBuffer: Buffer,
-): Result<RawMapComplexity, ValidateMapComplexityError> {
+): Result<RawMapMetadata & { difficultyName: string }, ValidateMapDifficultyError> {
   let map: any;
   try {
     map = parseJsonBuffer(mapBuffer);
   } catch (e) {
-    return { success: false, errors: [{ type: ValidateMapComplexityError.INVALID_FORMAT }] };
+    return { success: false, errors: [{ type: ValidateMapDifficultyError.INVALID_FORMAT }] };
   }
   const metadata = map.recordingMetadata;
   if (!metadata) {
-    return { success: false, errors: [{ type: ValidateMapComplexityError.INVALID_FORMAT }] };
+    return { success: false, errors: [{ type: ValidateMapDifficultyError.INVALID_FORMAT }] };
   }
   const requiredFields = {
     title: metadata.title,
@@ -336,19 +362,10 @@ function validateComplexity(
       return {
         success: false,
         errors: [{
-          type: ValidateMapComplexityError.MISSING_VALUES,
+          type: ValidateMapDifficultyError.MISSING_VALUES,
           message: `Property ${key} was missing a value`,
         }],
       };
-    }
-  }
-  if (requiredFields.complexity === 1) {
-    if (filename.endsWith('_Medium.rlrr')) {
-      requiredFields.complexity = 2;
-    } else if (filename.endsWith('_Hard.rlrr')) {
-      requiredFields.complexity = 3;
-    } else if (filename.endsWith('_Expert.rlrr')) {
-      requiredFields.complexity = 4;
     }
   }
   const optionalFields = {
@@ -356,7 +373,14 @@ function validateComplexity(
     author: metadata.creator,
     albumArt: metadata.coverImagePath,
   };
-  return { success: true, value: { ...requiredFields, ...optionalFields } };
+  const difficultyMatch = filename.match(/.*_(.+?).rlrr/);
+  if (difficultyMatch == null) {
+    return { success: false, errors: [{ type: ValidateMapDifficultyError.INVALID_FORMAT }] };
+  }
+  return {
+    success: true,
+    value: { ...requiredFields, ...optionalFields, difficultyName: difficultyMatch[1] },
+  };
 }
 
 function parseJsonBuffer(buffer: Buffer) {

--- a/src/db/maps/maps_repo.ts
+++ b/src/db/maps/maps_repo.ts
@@ -296,7 +296,7 @@ export async function validateMapFiles(
           // undefined for now, and look into generating a difficulty level later based on the map
           // content.
           difficulty: undefined,
-          difficultyName: path.basename(d.value.difficultyName),
+          difficultyName: d.value.difficultyName,
         })),
       albumArtFiles,
     },

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,7 +1,16 @@
 import pg from 'pg';
 
 // Connection details are pulled from env variables: https://node-postgres.com/features/connecting
-const pool = new pg.Pool();
+export const pool = new pg.Pool();
 pool.on('error', err => console.error(err));
 
-export default pool;
+export async function initPool() {
+  // Test DB
+  try {
+    await pool.connect();
+  } catch (e) {
+    throw new Error('Could not connect to database, is it running?');
+  }
+
+  return pool;
+}

--- a/src/db/users/users_repo.ts
+++ b/src/db/users/users_repo.ts
@@ -2,7 +2,7 @@ import { PromisedResult, ResultError } from 'base/result';
 import { createPassword } from 'crypto/crypto';
 import { CamelCase, camelCaseKeys, fromBytea, snakeCaseKeys, toBytea } from 'db/helpers';
 import { generateId, IdDomain } from 'db/id_gen';
-import pool from 'db/pool';
+import { pool } from 'db/pool';
 import * as db from 'zapatos/db';
 import { users } from 'zapatos/schema';
 import zxcvbn from 'zxcvbn';

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs/promises';
+
+export type EnvVars = {
+  pgUser: string,
+  pgPassword: string,
+  mapsDir: string,
+  sentryDsn: string,
+  sentryEnvironment: string,
+};
+
+export function initEnvVars() {
+  const _envVars: { [K in keyof EnvVars]: EnvVars[K] | undefined } = {
+    pgUser: process.env.PGUSER,
+    pgPassword: process.env.PGPASSWORD,
+    mapsDir: process.env.MAPS_DIR,
+    sentryDsn: process.env.SENTRY_DSN,
+    sentryEnvironment: process.env.SENTRY_ENV,
+  };
+  let fail = false;
+  for (const [key, value] of Object.entries(_envVars)) {
+    if (value == null) {
+      console.error(`${key} has been left blank in .env -- intentional?`);
+      fail = true;
+    }
+  }
+  const envVars = _envVars as EnvVars;
+  if (fail) {
+    throw new Error('One or more environment variables were missing, see above.');
+  }
+  try {
+    fs.access(envVars.mapsDir);
+  } catch (e) {
+    throw new Error('Could not access maps dir; ' + e);
+  }
+
+  return envVars;
+}

--- a/src/outage/index.html
+++ b/src/outage/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body style="font-family: monospace; font-size: 32px; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 16px;">
+    <img src="/favicon.png"/>
+    <div>ParaDB is temporarily down for maintenance. Check back soon!</div>
+  </body>
+</html>

--- a/src/outage/index.ts
+++ b/src/outage/index.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const app = express();
+
+app.get('/', (req, res) => {
+  res.sendFile(path.resolve(__dirname, 'index.html'));
+});
+app.get('/favicon.png', (req, res) => {
+  res.sendFile(path.resolve(__dirname, '../../static/favicon.png'));
+});
+app.listen(8080, () => {
+  console.log('Listening on 8080');
+});

--- a/src/zapatos/schema.d.ts
+++ b/src/zapatos/schema.d.ts
@@ -21,107 +21,107 @@ declare module 'zapatos/schema' {
 
   /* --- tables --- */
 
-  export namespace complexities {
-    export type Table = 'complexities';
+  export namespace difficulties {
+    export type Table = 'difficulties';
     export interface Selectable {
       /**
-      * **complexities.map_id**
+      * **difficulties.map_id**
       * - `varchar` in database
       * - `NOT NULL`, no default
       */
       map_id: string;
       /**
-      * **complexities.complexity**
+      * **difficulties.difficulty**
       * - `int4` in database
-      * - `NOT NULL`, no default
+      * - Nullable, no default
       */
-      complexity: number;
+      difficulty: number | null;
       /**
-      * **complexities.complexity_name**
+      * **difficulties.difficulty_name**
       * - `varchar` in database
       * - Nullable, no default
       */
-      complexity_name: string | null;
+      difficulty_name: string | null;
     }
     export interface JSONSelectable {
       /**
-      * **complexities.map_id**
+      * **difficulties.map_id**
       * - `varchar` in database
       * - `NOT NULL`, no default
       */
       map_id: string;
       /**
-      * **complexities.complexity**
+      * **difficulties.difficulty**
       * - `int4` in database
-      * - `NOT NULL`, no default
+      * - Nullable, no default
       */
-      complexity: number;
+      difficulty: number | null;
       /**
-      * **complexities.complexity_name**
+      * **difficulties.difficulty_name**
       * - `varchar` in database
       * - Nullable, no default
       */
-      complexity_name: string | null;
+      difficulty_name: string | null;
     }
     export interface Whereable {
       /**
-      * **complexities.map_id**
+      * **difficulties.map_id**
       * - `varchar` in database
       * - `NOT NULL`, no default
       */
       map_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-      * **complexities.complexity**
+      * **difficulties.difficulty**
       * - `int4` in database
-      * - `NOT NULL`, no default
+      * - Nullable, no default
       */
-      complexity?: number | db.Parameter<number> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, number | db.Parameter<number> | db.SQLFragment | db.ParentColumn>;
+      difficulty?: number | db.Parameter<number> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, number | db.Parameter<number> | db.SQLFragment | db.ParentColumn>;
       /**
-      * **complexities.complexity_name**
+      * **difficulties.difficulty_name**
       * - `varchar` in database
       * - Nullable, no default
       */
-      complexity_name?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+      difficulty_name?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
     }
     export interface Insertable {
       /**
-      * **complexities.map_id**
+      * **difficulties.map_id**
       * - `varchar` in database
       * - `NOT NULL`, no default
       */
       map_id: string | db.Parameter<string> | db.SQLFragment;
       /**
-      * **complexities.complexity**
+      * **difficulties.difficulty**
       * - `int4` in database
-      * - `NOT NULL`, no default
+      * - Nullable, no default
       */
-      complexity: number | db.Parameter<number> | db.SQLFragment;
+      difficulty?: number | db.Parameter<number> | null | db.DefaultType | db.SQLFragment;
       /**
-      * **complexities.complexity_name**
+      * **difficulties.difficulty_name**
       * - `varchar` in database
       * - Nullable, no default
       */
-      complexity_name?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment;
+      difficulty_name?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment;
     }
     export interface Updatable {
       /**
-      * **complexities.map_id**
+      * **difficulties.map_id**
       * - `varchar` in database
       * - `NOT NULL`, no default
       */
       map_id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
       /**
-      * **complexities.complexity**
+      * **difficulties.difficulty**
       * - `int4` in database
-      * - `NOT NULL`, no default
+      * - Nullable, no default
       */
-      complexity?: number | db.Parameter<number> | db.SQLFragment | db.SQLFragment<any, number | db.Parameter<number> | db.SQLFragment>;
+      difficulty?: number | db.Parameter<number> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, number | db.Parameter<number> | null | db.DefaultType | db.SQLFragment>;
       /**
-      * **complexities.complexity_name**
+      * **difficulties.difficulty_name**
       * - `varchar` in database
       * - Nullable, no default
       */
-      complexity_name?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
+      difficulty_name?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
     }
     export type UniqueIndex = never;
     export type Column = keyof Selectable;
@@ -181,6 +181,12 @@ declare module 'zapatos/schema' {
       * - Nullable, no default
       */
       album_art: string | null;
+      /**
+      * **maps.complexity**
+      * - `int4` in database
+      * - Nullable, no default
+      */
+      complexity: number | null;
     }
     export interface JSONSelectable {
       /**
@@ -231,6 +237,12 @@ declare module 'zapatos/schema' {
       * - Nullable, no default
       */
       album_art: string | null;
+      /**
+      * **maps.complexity**
+      * - `int4` in database
+      * - Nullable, no default
+      */
+      complexity: number | null;
     }
     export interface Whereable {
       /**
@@ -281,6 +293,12 @@ declare module 'zapatos/schema' {
       * - Nullable, no default
       */
       album_art?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+      /**
+      * **maps.complexity**
+      * - `int4` in database
+      * - Nullable, no default
+      */
+      complexity?: number | db.Parameter<number> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, number | db.Parameter<number> | db.SQLFragment | db.ParentColumn>;
     }
     export interface Insertable {
       /**
@@ -331,6 +349,12 @@ declare module 'zapatos/schema' {
       * - Nullable, no default
       */
       album_art?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment;
+      /**
+      * **maps.complexity**
+      * - `int4` in database
+      * - Nullable, no default
+      */
+      complexity?: number | db.Parameter<number> | null | db.DefaultType | db.SQLFragment;
     }
     export interface Updatable {
       /**
@@ -381,6 +405,12 @@ declare module 'zapatos/schema' {
       * - Nullable, no default
       */
       album_art?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
+      /**
+      * **maps.complexity**
+      * - `int4` in database
+      * - Nullable, no default
+      */
+      complexity?: number | db.Parameter<number> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, number | db.Parameter<number> | null | db.DefaultType | db.SQLFragment>;
     }
     export type UniqueIndex = 'maps_pkey';
     export type Column = keyof Selectable;
@@ -650,62 +680,62 @@ declare module 'zapatos/schema' {
 
   /* === cross-table types === */
 
-  export type Table = complexities.Table | maps.Table | users.Table;
-  export type Selectable = complexities.Selectable | maps.Selectable | users.Selectable;
-  export type JSONSelectable = complexities.JSONSelectable | maps.JSONSelectable | users.JSONSelectable;
-  export type Whereable = complexities.Whereable | maps.Whereable | users.Whereable;
-  export type Insertable = complexities.Insertable | maps.Insertable | users.Insertable;
-  export type Updatable = complexities.Updatable | maps.Updatable | users.Updatable;
-  export type UniqueIndex = complexities.UniqueIndex | maps.UniqueIndex | users.UniqueIndex;
-  export type Column = complexities.Column | maps.Column | users.Column;
-  export type AllTables = [complexities.Table, maps.Table, users.Table];
+  export type Table = difficulties.Table | maps.Table | users.Table;
+  export type Selectable = difficulties.Selectable | maps.Selectable | users.Selectable;
+  export type JSONSelectable = difficulties.JSONSelectable | maps.JSONSelectable | users.JSONSelectable;
+  export type Whereable = difficulties.Whereable | maps.Whereable | users.Whereable;
+  export type Insertable = difficulties.Insertable | maps.Insertable | users.Insertable;
+  export type Updatable = difficulties.Updatable | maps.Updatable | users.Updatable;
+  export type UniqueIndex = difficulties.UniqueIndex | maps.UniqueIndex | users.UniqueIndex;
+  export type Column = difficulties.Column | maps.Column | users.Column;
+  export type AllTables = [difficulties.Table, maps.Table, users.Table];
   export type AllMaterializedViews = [];
 
 
   export type SelectableForTable<T extends Table> = {
-    complexities: complexities.Selectable;
+    difficulties: difficulties.Selectable;
     maps: maps.Selectable;
     users: users.Selectable;
   }[T];
 
   export type JSONSelectableForTable<T extends Table> = {
-    complexities: complexities.JSONSelectable;
+    difficulties: difficulties.JSONSelectable;
     maps: maps.JSONSelectable;
     users: users.JSONSelectable;
   }[T];
 
   export type WhereableForTable<T extends Table> = {
-    complexities: complexities.Whereable;
+    difficulties: difficulties.Whereable;
     maps: maps.Whereable;
     users: users.Whereable;
   }[T];
 
   export type InsertableForTable<T extends Table> = {
-    complexities: complexities.Insertable;
+    difficulties: difficulties.Insertable;
     maps: maps.Insertable;
     users: users.Insertable;
   }[T];
 
   export type UpdatableForTable<T extends Table> = {
-    complexities: complexities.Updatable;
+    difficulties: difficulties.Updatable;
     maps: maps.Updatable;
     users: users.Updatable;
   }[T];
 
   export type UniqueIndexForTable<T extends Table> = {
-    complexities: complexities.UniqueIndex;
+    difficulties: difficulties.UniqueIndex;
     maps: maps.UniqueIndex;
     users: users.UniqueIndex;
   }[T];
 
   export type ColumnForTable<T extends Table> = {
-    complexities: complexities.Column;
+    difficulties: difficulties.Column;
     maps: maps.Column;
     users: users.Column;
   }[T];
 
   export type SQLForTable<T extends Table> = {
-    complexities: complexities.SQL;
+    difficulties: difficulties.SQL;
     maps: maps.SQL;
     users: users.SQL;
   }[T];


### PR DESCRIPTION
This PR:
 - Renames the `complexities` table to `difficulties`
 - Renames the `complexity` and `complexity_name` columns to `difficulty` and `difficulty_name`
 - Adds a new `complexity` int property to the Map schema
 - Makes it so that `difficulty_name` is pulled from the rlrr filename (`difficulty` is unused at the moment)
